### PR TITLE
43 cant install on latest fabric loader version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -74,7 +74,8 @@ tasks.processResources {
             "version" to libs.versions.project.get(),
             "minecraft_version" to libs.versions.minecraft.get(),
             "loader_version" to libs.versions.fabric.loader.get(),
-            "fabric_permissions_api_version" to libs.versions.fabric.permissions.api.get()
+            "fabric_permissions_api_version" to libs.versions.fabric.permissions.api.get(),
+            "luckperms_version" to libs.versions.luckperms.get()
         )
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,12 +3,12 @@
 # Fabric
 # check these on https://modmuss50.me/fabric.html
 fabric-api = '0.135.0+1.21.10'
-fabric-loader = '0.17.3'
-fabric-loom = '1.11.8'
+fabric-loader = '0.18.1'
+fabric-loom = '1.13.6'
 fabric-permissions-api = '0.5.0'
 
 # Jackson
-jackson = '3.0.0'
+jackson = '3.0.3'
 jackson-annotations = '2.20'
 
 # Jakarta
@@ -30,7 +30,7 @@ minecraft = '1.21.10'
 project = '1.21.10+build.4'
 
 # Yarn
-yarn = '1.21.10+build.2'
+yarn = '1.21.10+build.3'
 
 [libraries]
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,6 +20,9 @@ java = '21'
 # Kotlin
 kotlin = '2.2.20'
 
+# LuckPerms
+luckperms = 'v5.5.17-fabric'
+
 # Minecraft
 minecraft = '1.21.10'
 

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -44,14 +44,17 @@
     }
   ],
   "mixins": [
-     "keep_it_personal.mixins.json"
+    "keep_it_personal.mixins.json"
   ],
   "depends": {
     "fabricloader": "~${loader_version}",
     "fabric": "*",
-    "minecraft": "${minecraft_version}"
+    "minecraft": "~${minecraft_version}"
   },
   "suggests": {
-    "fabric-permissions-api-v0": "~${fabric_permissions_api_version}"
+    "luckperms": "~${luckperms_version}"
+  },
+  "conflicts": {
+    "individualkeepinv": "*"
   }
 }


### PR DESCRIPTION
# Changes
* Added [LuckPerms](https://modrinth.com/plugin/luckperms) to suggested mods
* Added [Individual Keep Inventory](https://modrinth.com/mod/individual-keep-inventory) and [Individual Keep Inventory (Updated)](https://modrinth.com/mod/individual-keep-inventory-(updated)) to conflicting mods

# Dependency Upgrades
* Fabric Loader: `0.17.3` → `0.18.1`
* Fabric Loom: `1.11.8` → `1.13.6`
* Yarn: `1.21.10+build.4`